### PR TITLE
[CLOUD-2195] Clean up the left-over content of the history directory if it exists

### DIFF
--- a/modules/sso/install
+++ b/modules/sso/install
@@ -10,7 +10,9 @@ pushd $JBOSS_HOME/bin
 ./jboss-cli.sh --file=keycloak-install.cli
 popd
 
+# Clean up the left-over content of the history directory
+rm -rf "$JBOSS_HOME/standalone/configuration/standalone_xml_history/current"
+
 chown -R jboss:root $JBOSS_HOME
 chmod 0755 $JBOSS_HOME
 chmod -R g+rwX $JBOSS_HOME
-


### PR DESCRIPTION

since this is causing issues when running RH-SSO 7.1 for OpenShift image, e.g. on:
* overlayfs and aufs storage drivers, or
* on AWS and Azure environments

Fixes: https://issues.jboss.org/browse/CLOUD-2195
Fixes: https://github.com/openshift/openshift-ansible/issues/2823

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

PTAL

Thank you, Jan
