### PR TITLE
[Post Sprint-14 cleanup] Point the 'from' field of sso72-dev standalone image back to "jboss-eap-7/eap71:latest"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
 version: "7.2.0"
-from: "jboss-eap-7/eap71:7.1.0-9"
+from: "jboss-eap-7/eap71:latest"
 labels:
     - name: "org.jboss.product"
       value: "sso"


### PR DESCRIPTION

This change undoes the change done within https://github.com/jboss-container-images/redhat-sso-7-image/pull/26. We have now got the release ```sso72``` branch, thus bringing ```sso72-dev``` one to be up2date / latest.

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
