### PR TITLE
[CLOUD-2195] Clean up the left-over content of the history directory if it exists

### DIFF
--- a/modules/sso/install
+++ b/modules/sso/install
@@ -10,7 +10,9 @@ pushd $JBOSS_HOME/bin
 ./jboss-cli.sh --file=keycloak-install.cli
 popd
 
+# Clean up the left-over content of the history directory
+rm -rf "$JBOSS_HOME/standalone/configuration/standalone_xml_history/current"
+
 chown -R jboss:root $JBOSS_HOME
 chmod 0755 $JBOSS_HOME
 chmod -R g+rwX $JBOSS_HOME
-


### PR DESCRIPTION
since this is causing issues when running RH-SSO 7.2 for OpenShift image, e.g. on:
* overlayfs and aufs storage drivers, or
* on AWS and Azure environments

Apply the fix for CLOUD-2195 issue against ```sso72``` branch too.

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
