### PR TITLE
Backport of [CLOUD-2347] Container namespace switch change to sso72-cp branch

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -5,6 +5,8 @@ description: "Red Hat Single Sign-On 7.2 container image"
 version: "7.2.1"
 from: "jboss-eap-7/eap71:7.1.1-2"
 labels:
+    - name: "com.redhat.component"
+      value: "redhat-sso-7-sso72-container"
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
@@ -37,5 +39,5 @@ run:
           - "standalone.xml"
 osbs:
       repository:
-            name: redhat-sso-7-docker
+            name: containers/redhat-sso-7
             branch: jb-sso-7.2-rhel-7


### PR DESCRIPTION

Adapt Marek's change from https://github.com/jboss-container-images/redhat-sso-7-image/pull/37/commits/3cde4abb88e0c44487d33698b8fa3a3b5f27d82f to ```sso72-cp``` branch.

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
