### PR TITLE
Use override file to set cp's build branch

### DIFF
--- a/override-cp.yaml
+++ b/override-cp.yaml
@@ -1,0 +1,3 @@
+osbs:
+      repository:
+            branch: jb-sso-7.2-cp-rhel-7


### PR DESCRIPTION
To be used like this: `--overrides override-cp.yaml`

The build branch is set to `-cp-rhel-7`, which contains a `container.yaml`,
causing the OSBS build tag to be :cp instead of :latest.