### PR TITLE
sso72-cp to sso72-dev branches sync post the release of RH-SSO 7.2.2.GA image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.1"
+version: "7.2.2"
 from: "jboss-eap-7/eap71:latest"
 labels:
     - name: "com.redhat.component"
@@ -10,25 +10,25 @@ labels:
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.6.Final-redhat-1.zip
+      # keycloak-server-overlay-3.4.8.Final-redhat-6.zip
     - path: keycloak-server-overlay.zip
-      md5: b10c7c602749ab493e2b94cd29cdf0b8
+      md5: bfeec4972b9bc0ef454173d56b8df474
 run:
       user: 185
       cmd:


### PR DESCRIPTION

Sync the content of ```sso72-dev``` branch with the content of ```sso72-cp``` branch post the release of RH-SSO 7.2.2.GA image version. Perform this by cherrypicking the:

- [Update to RH-SSO 7.2.2.CR1 ](https://github.com/jboss-container-images/redhat-sso-7-image/commit/561140d1187d3cb4297945c3add58ee9eafbc44e)

change. Rest of the changes are already present.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
