### PR TITLE
Add override-dev.yaml to target correct branch

### DIFF
--- a/override-dev.yaml
+++ b/override-dev.yaml
@@ -1,0 +1,4 @@
+osbs:
+      repository:
+            name: containers/redhat-sso-7
+            branch: jb-sso-7.3-dev-rhel-7


### PR DESCRIPTION
This follows the pattern from 72 cp, where a branch-specific overrides file is used to avoid some merge conflicts between branches.