### PR TITLE
Sync content of sso72-cp to sso72-dev branch post RH-SSO 7.2.3.GA release

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.2"
+version: "7.2.3"
 from: "jboss-eap-7/eap71:latest"
 labels:
     - name: "com.redhat.component"
@@ -10,25 +10,25 @@ labels:
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.8.Final-redhat-6.zip
+      # keycloak-server-overlay-3.4.10.Final-redhat-1.zip
     - path: keycloak-server-overlay.zip
-      md5: bfeec4972b9bc0ef454173d56b8df474
+      md5: 3db0704ebb5e5f42a8e995d7f1905408
 run:
       user: 185
       cmd:


### PR DESCRIPTION
Synchronize the content of `sso72-cp` to `sso72-dev` branches post the RH-SSO 7.2.3.GA release by updating to RH-SSO 7.2.3.CR2 Keycloak server overlay zip archive.

(analogous change like in https://github.com/jboss-container-images/redhat-sso-7-image/pull/50 , but against `sso72-dev` branch this time).

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
