### PR TITLE
Update to RH-SSO 7.2.6.CR1

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -26,9 +26,9 @@ modules:
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.9.Final-redhat-1.zip
+      # keycloak-server-overlay-3.4.10.Final-redhat-1.zip
     - path: keycloak-server-overlay.zip
-      md5: 0582ad97e373d2ab373af7d899fdb036
+      md5: 3db0704ebb5e5f42a8e995d7f1905408
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -2,33 +2,33 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.2"
-from: "jboss-eap-7/eap71:7.1.2-2"
+version: "7.2.3"
+from: "jboss-eap-7/eap71:7.1.3-3"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso72-container"
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.2.GA"
+      value: "7.2.3.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.8.Final-redhat-6.zip
+      # keycloak-server-overlay-3.4.9.Final-redhat-1.zip
     - path: keycloak-server-overlay.zip
-      md5: bfeec4972b9bc0ef454173d56b8df474
+      md5: 0582ad97e373d2ab373af7d899fdb036
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -2,33 +2,33 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.4"
-from: "jboss-eap-7/eap71:7.1.4-1"
+version: "7.2.5"
+from: "jboss-eap-7/eap71:7.1.5-1"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso72-container"
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.4.GA"
+      value: "7.2.5.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.4.GA"
+      value: "7.2.5.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.4.GA"
+      value: "7.2.5.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.4.GA"
+      value: "7.2.5.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.12.Final-redhat-2.zip
+      # keycloak-server-overlay-3.4.13.Final-redhat-00001.zip
     - path: keycloak-server-overlay.zip
-      md5: 06c3cbc85867ea42569de203035547ca
+      md5: 3c48e31757a2e6072eb183364947d3fe
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
 version: "7.2.5"
-from: "jboss-eap-7/eap71:7.1.5-1"
+from: "jboss-eap-7/eap71:7.1.5-2"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso72-container"
@@ -26,9 +26,9 @@ modules:
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.13.Final-redhat-00001.zip
+      # keycloak-server-overlay-3.4.14.Final-redhat-00001.zip
     - path: keycloak-server-overlay.zip
-      md5: 3c48e31757a2e6072eb183364947d3fe
+      md5: fcdd8c6f60fe9918169dc6dc34b27be7
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -2,33 +2,33 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.3"
-from: "jboss-eap-7/eap71:7.1.3-3"
+version: "7.2.4"
+from: "jboss-eap-7/eap71:7.1.4-1"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso72-container"
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.3.GA"
+      value: "7.2.4.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.3.GA"
+      value: "7.2.4.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.3.GA"
+      value: "7.2.4.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.3.GA"
+      value: "7.2.4.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.10.Final-redhat-1.zip
+      # keycloak-server-overlay-3.4.12.Final-redhat-2.zip
     - path: keycloak-server-overlay.zip
-      md5: 3db0704ebb5e5f42a8e995d7f1905408
+      md5: 06c3cbc85867ea42569de203035547ca
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -2,31 +2,31 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.1"
-from: "jboss-eap-7/eap71:7.1.1-2"
+version: "7.2.2"
+from: "jboss-eap-7/eap71:7.1.2-2"
 labels:
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.1.GA"
+      value: "7.2.2.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.6.Final-redhat-1.zip
+      # keycloak-server-overlay-3.4.8.Final-redhat-6.zip
     - path: keycloak-server-overlay.zip
-      md5: b10c7c602749ab493e2b94cd29cdf0b8
+      md5: bfeec4972b9bc0ef454173d56b8df474
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.5"
+version: "7.2.6"
 from: "jboss-eap-7/eap71:7.1.5-2"
 labels:
     - name: "com.redhat.component"
@@ -10,25 +10,25 @@ labels:
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.5.GA"
+      value: "7.2.6.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.5.GA"
+      value: "7.2.6.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.5.GA"
+      value: "7.2.6.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.5.GA"
+      value: "7.2.6.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.14.Final-redhat-00001.zip
-    - path: keycloak-server-overlay.zip
-      md5: fcdd8c6f60fe9918169dc6dc34b27be7
+    - path: keycloak-server-overlay-3.4.15.Final-redhat-00001.zip
+      target: keycloak-server-overlay.zip
+      md5: 57102bb07c21012f4c0fbbb75b4ce144
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -5,6 +5,8 @@ description: "Red Hat Single Sign-On 7.2 container image"
 version: "7.2.1"
 from: "jboss-eap-7/eap71:7.1.1-2"
 labels:
+    - name: "com.redhat.component"
+      value: "redhat-sso-7-sso72-container"
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
@@ -37,5 +39,5 @@ run:
           - "standalone.xml"
 osbs:
       repository:
-            name: redhat-sso-7-docker
+            name: containers/redhat-sso-7
             branch: jb-sso-7.2-rhel-7

--- a/image.yaml
+++ b/image.yaml
@@ -2,31 +2,31 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.0"
-from: "jboss-eap-7/eap71:7.1.0-9"
+version: "7.2.1"
+from: "jboss-eap-7/eap71:7.1.1-2"
 labels:
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.0.GA"
+      value: "7.2.1.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.0.GA"
+      value: "7.2.1.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.0.GA"
+      value: "7.2.1.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.0.GA"
+      value: "7.2.1.GA"
 modules:
       repositories:
           - path: modules
       install:
           - name: sso
 artifacts:
-      # keycloak-server-overlay-3.4.3.Final-redhat-2.zip
+      # keycloak-server-overlay-3.4.6.Final-redhat-1.zip
     - path: keycloak-server-overlay.zip
-      md5: 0a14c3ee7be9e20c25c31b082a2c2c49
+      md5: b10c7c602749ab493e2b94cd29cdf0b8
 run:
       user: 185
       cmd:

--- a/modules/sso/install
+++ b/modules/sso/install
@@ -10,7 +10,9 @@ pushd $JBOSS_HOME/bin
 ./jboss-cli.sh --file=keycloak-install.cli
 popd
 
+# Clean up the left-over content of the history directory
+rm -rf "$JBOSS_HOME/standalone/configuration/standalone_xml_history/current"
+
 chown -R jboss:root $JBOSS_HOME
 chmod 0755 $JBOSS_HOME
 chmod -R g+rwX $JBOSS_HOME
-

--- a/override-cp.yaml
+++ b/override-cp.yaml
@@ -1,0 +1,3 @@
+osbs:
+      repository:
+            branch: jb-sso-7.2-cp-rhel-7

--- a/override-cp.yaml
+++ b/override-cp.yaml
@@ -1,3 +1,4 @@
 osbs:
       repository:
+            name: containers/redhat-sso-7
             branch: jb-sso-7.2-cp-rhel-7


### PR DESCRIPTION
This PR also allows to bypass CE caching service by specifying full artifact name (including version). This is very convenient since it downloads artifacts directly from Brew.