### PR TITLE
[KEYCLOAK-9604] Rebase on top of EAP 7.2.0 image of release 10

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "redhat-sso-7/sso73"
 description: "Red Hat Single Sign-On 7.3 container image"
 version: "7.3.0.GA"
-from: "jboss-eap-7/eap72:7.2.0-9"
+from: "jboss-eap-7/eap72:7.2.0-10"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso73-container"


### PR DESCRIPTION
`jboss-eap-7/eap72:7.2.0-10` to inherit the systemd [CVE-2019-6454](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-6454) fix from [RHSA-2019:0368](https://access.redhat.com/errata/RHSA-2019:0368)

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

References:
https://access.redhat.com/security/cve/cve-2019-6454

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
