### PR TITLE
[KEYCLOAK-9978] Prepare for RH-SSO 7.2.7.GA for OpenShift image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,24 +2,24 @@ schema_version: 1
 
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
-version: "7.2.6"
-from: "jboss-eap-7/eap71:7.1.6-2"
+version: "7.2.7"
+from: "jboss-eap-7/eap71:7.1.6-3.1553789877"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso72-container"
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.2.6.GA"
+      value: "7.2.7.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.2.6.GA"
+      value: "7.2.7.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.2.6.GA"
+      value: "7.2.7.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.2.6.GA"
+      value: "7.2.7.GA"
 modules:
       repositories:
           - path: modules
@@ -27,8 +27,8 @@ modules:
           - name: sso
 artifacts:
     - target: keycloak-server-overlay.zip
-      name: keycloak-server-overlay-3.4.15.Final-redhat-00001.zip
-      md5: 57102bb07c21012f4c0fbbb75b4ce144
+      name: keycloak-server-overlay-3.4.17.Final-redhat-00001.zip
+      md5:  13b3cd27ec9e882323ba7b1b410a5bd3
 run:
       user: 185
       cmd:


### PR DESCRIPTION
Update:
* EAP image version to pick up libssh2 CVE fixes from RHSA-2019:0679,
* RH-SSO version (Keycloak server overlay & its MD5 sum) to 7.2.7.CR1,
* RH-SSO image version to prepare for 7.2.7.GA

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
