### PR TITLE
[KEYCLOAK-9978] Rebase RH-SSO 7.2.7 image on top of EAP "jboss-eap-7/eap71:7.1.6-3.1554788570"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "redhat-sso-7/sso72"
 description: "Red Hat Single Sign-On 7.2 container image"
 version: "7.2.7"
-from: "jboss-eap-7/eap71:7.1.6-3.1553789877"
+from: "jboss-eap-7/eap71:7.1.6-3.1554788570"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso72-container"


### PR DESCRIPTION
in order to pick up the python CVE-2019-9636 fix from RHSA-2019:0710

See [RHSA-2019:0710](https://access.redhat.com/errata/RHSA-2019:0710) for details

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
