### PR TITLE
[RHSSO-1743] Update to EAP 7.2.1.CP.CR2. Pick up libssh2 & python CVE fixes

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "redhat-sso-7/sso73"
 description: "Red Hat Single Sign-On 7.3 container image"
 version: "7.3.1.GA"
-from: "jboss-eap-7/eap72:7.2.1-1"
+from: "jboss-eap-7/eap72:7.2.1-3"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso73-container"


### PR DESCRIPTION

This updates:
* The intermediary EAP image to EAP 7.2.1.CP.CR2 release,
* The libssh2 RPM to NVR expected by the [RHSA-2019:0679](https://access.redhat.com/errata/RHSA-2019:0679) CVE fix, and
* The python RPM to NVR expected by the [RHSA-2019:0710](https://access.redhat.com/errata/RHSA-2019:0710) CVE fix

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
