### PR TITLE
[KEYCLOAK-10108] Rebase on top of EAP image of version "7.2.1" and release "4" (eap72:7.2.1-4)

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "redhat-sso-7/sso73"
 description: "Red Hat Single Sign-On 7.3 container image"
 version: "7.3.1.GA"
-from: "jboss-eap-7/eap72:7.2.1-3"
+from: "jboss-eap-7/eap72:7.2.1-4"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso73-container"


### PR DESCRIPTION
to inherit the java-1.8.0-openjdk CVE fixes from [RHSA-2019:0775](https://access.redhat.com/errata/RHSA-2019:0775)

This updates the internal `java-1.8.0-openjdk` RPM version in the image to the `java-1.8.0-openjdk-1.8.0.212.b04-0.el7_6.x86_64.rpm` one, expected by [RHSA-2019:0775](https://access.redhat.com/errata/RHSA-2019:0775)

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
