### PR TITLE
[KEYCLOAK-10694] Rebase the Red Hat Single Sign-On container image on top of the Red Hat Universal Base Image 8 Minimal image. on top of the Red Hat Universal Base Image 8 Minimal image. [KEYCLOAK-10124] Define RHEL-8 content set

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,9 @@
 # Red Hat Single Sign-On container image
 
-NOTE: Extends link:https://github.com/jboss-container-images/jboss-eap-7-image[JBoss EAP 7 image]
+Extends link:https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/ubi8/ubi-minimal[Red Hat Universal Base Image 8 Minimal] by utilizing:
+
+* link:https://cekit.io/[CEKit] modules link:https://github.com/jboss-openshift/cct_module[shared by OpenShift container images]
+* link:https://github.com/jboss-container-images/jboss-eap-modules[JBoss EAP] modules.
 
 # License
 

--- a/backward-compatibility/README.adoc
+++ b/backward-compatibility/README.adoc
@@ -1,0 +1,3 @@
+# Various Red Hat Single Sign-On container image link:https://docs.cekit.io/en/latest/descriptor/image.html[image descriptors] for link:https://cekit.io/[CEKit] to preserve backward compatibility
+
+This directory contains definition of various image descriptor files for the Red Hat Single Sign-On container image, needed to ensure backward compatibility (reproducible image (reb)uilds over time). Such descriptor files need to be archived, in case of a major link:https://cekit.io/[CEKit] tool upgrade, leading to backward-incompatible changes, for example the link:https://cekit.io/blog/2019/04/module-merging-changes/[module merging change] introduced in link:https://cekit.io/blog/2019/04/cekit-3.0.0-released/[CEKit v3.0.0].

--- a/backward-compatibility/cekit-2.x-image-descriptor.yaml
+++ b/backward-compatibility/cekit-2.x-image-descriptor.yaml
@@ -3,9 +3,7 @@ schema_version: 1
 name: "redhat-sso-cd-tech-preview/sso-cd"
 description: "Red Hat Single Sign-On Continuous Delivery container image"
 version: "6"
-# Strictly stick to 'ubi8-minimal:8.0-131' rather than using 'ubi8-minimal:latest'
-# till RH BZ#1725863 is addressed
-from: "ubi8-minimal:8.0-131"
+from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-7-sso-cd-container"
@@ -23,27 +21,29 @@ envs:
     - name: "PRODUCT_VERSION"
       value: "6"
 packages:
-      manager: microdnf
+    repositories:
+        - jboss-os
 modules:
       repositories:
-          - path: modules
+          - path: ../modules
           - name: cct_module
             git:
                 url: https://github.com/jboss-openshift/cct_module.git
-                ref: sprint-35
+                ref: sprint-31
           - name: jboss-eap-7-image
             git:
                 url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                ref: CD16
+                ref: CD16-CR1
       install:
           - name: jboss.container.openjdk.jdk
-            version: '11'
+            version: "8"
           - name: eap-cd-latest
           - name: sso
           - name: keycloak.openshift.clients
-# artifacts:
-      # Set by the pipeline. Consists of the server overlay zip, renamed to "keycloak-server-overlay.zip"
-      # Use overrides/local-keycloak-zips-overrides.yaml to build the image using specific artifacts, stored locally
+artifacts:
+      # keycloak-server-overlay-4.0.0.Beta3-redhat-2.zip
+    - path: keycloak-server-overlay.zip
+      md5: 5dde7dcb52e76bb1373cbaa020328d4c
 run:
       user: 185
       cmd:

--- a/image.yaml
+++ b/image.yaml
@@ -1,14 +1,14 @@
 schema_version: 1
 
-name: "redhat-sso-cd-tech-preview/sso-cd"
-description: "Red Hat Single Sign-On Continuous Delivery container image"
+name: "redhat-sso-cd-tech-preview/sso-cd-rhel8"
+description: "Red Hat Single Sign-On Continuous Delivery container image, based on the Red Hat Universal Base Image 8 Minimal container image"
 version: "6"
 # Strictly stick to 'ubi8-minimal:8.0-131' rather than using 'ubi8-minimal:latest'
 # till RH BZ#1725863 is addressed
 from: "ubi8-minimal:8.0-131"
 labels:
     - name: "com.redhat.component"
-      value: "redhat-sso-7-sso-cd-container"
+      value: "redhat-sso-cd-rhel8-container"
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
@@ -58,4 +58,4 @@ run:
 osbs:
       repository:
             name: containers/redhat-sso-7
-            branch: jb-sso-cd-rhel-7
+            branch: jb-sso-cd-rhel8

--- a/image.yaml
+++ b/image.yaml
@@ -24,6 +24,9 @@ envs:
       value: "6"
 packages:
       manager: microdnf
+      content_sets:
+            x86_64:
+                - rhel-8-for-x86_64-baseos-rpms
 modules:
       repositories:
           - path: modules

--- a/override-dev.yaml
+++ b/override-dev.yaml
@@ -1,4 +1,0 @@
-osbs:
-      repository:
-            name: containers/redhat-sso-7
-            branch: jb-sso-cd-dev-rhel-7

--- a/overrides/README.adoc
+++ b/overrides/README.adoc
@@ -1,0 +1,49 @@
+# Various link:https://cekit.io/[CEKit] Overrides modules for the Red Hat Single Sign-On container image
+
+link:https://cekit.io/[CEKit] provides link:https://docs.cekit.io/en/latest/handbook/overrides.html[Overrides] feature to customize image builds (e.g. use different base image, include different version of specific libraries etc.). It's even possible to link:https://docs.cekit.io/en/latest/handbook/overrides.html#overrides-chaining[chain multiple overrides] to combine the requests together. See the following examples for guidance on how to customize the build of the Red Hat Single Sign-On container image to achieve this:
+
+* Modify the build of Red Hat Single Sign-On container image to deploy OpenJDK JDK 8 (OpenJDK JDK 11 is used by default):
++
+** To build using CEKit 2.x use command:
++
+[source,bash,subs="attributes+,macros+"]
+----
+cekit build \
+--descriptor backward-compatibility/cekit-2.x-image-descriptor.yaml \
+--overrides-file overrides/jdk8-overrides.yaml \
+--build-engine=docker
+----
++
+NOTE: When building with CEKit 2.x, the link:https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/rhel7[Red Hat Enterprise Linux 7] image is used as the base image for the output Red Hat Single Sign-On container image and the link:http://yum.baseurl.org/[Yum package manager] is used to install the required RPM packages.
++
+** To build using CEKit 3.x use command:
++
+[source,bash,subs="attributes+,macros+"]
+----
+cekit build \
+--overrides-file overrides/jdk8-overrides.yaml \
+docker
+----
++
+NOTE: When building with CEKit 3.x, the link:https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/ubi8/ubi-minimal[Red Hat Universal Base Image 8 Minimal] image (the default one) is used as the base image for the output Red Hat Single Sign-On container image and the link:https://github.com/rpm-software-management/microdnf[microdnf] lightweight implementation of dnf is used to install the required RPM packages.
+
+* Modify the build of Red Hat Single Sign-On container image to use custom Keycloak artifacts, downloaded in advance and stored locally for the build:
++
+** To build using CEKit 2.x use command:
++
+[source,bash,subs="attributes+,macros+"]
+----
+cekit build \
+--descriptor backward-compatibility/cekit-2.x-image-descriptor.yaml \
+--overrides-file overrides/local-keycloak-zips-overrides.yaml \
+--build-engine=docker
+----
++
+** To build using CEKit 3.x use command:
++
+[source,bash,subs="attributes+,macros+"]
+----
+cekit build \
+--overrides-file overrides/local-keycloak-zips-overrides.yaml \
+docker
+----

--- a/overrides/jdk11-overrides.yaml
+++ b/overrides/jdk11-overrides.yaml
@@ -1,0 +1,9 @@
+# CEKit Overrides module to deploy OpenJDK JDK 11 into the Red Hat Single Sign-On container image
+# See README.adoc and https://docs.cekit.io/en/latest/handbook/overrides.html for details
+#
+# NOTE: OpenJDK JDK 11 is the default JDK version for the Red Hat Single Sign-On Continuous Delivery
+#       container image, starting from version 7.0
+modules:
+      install:
+          - name: jboss.container.openjdk.jdk
+            version: "11"

--- a/overrides/jdk8-overrides.yaml
+++ b/overrides/jdk8-overrides.yaml
@@ -1,0 +1,6 @@
+# CEKit Overrides module to deploy OpenJDK JDK 8 into the Red Hat Single Sign-On container image
+# See README.adoc and https://docs.cekit.io/en/latest/handbook/overrides.html for details
+modules:
+      install:
+          - name: jboss.container.openjdk.jdk
+            version: "8"

--- a/overrides/local-keycloak-zips-overrides.yaml
+++ b/overrides/local-keycloak-zips-overrides.yaml
@@ -1,7 +1,6 @@
-osbs:
-      repository:
-            name: containers/redhat-sso-7
-            branch: jb-sso-cd-dev-rhel-7
+# CEKit Overrides module to build the Red Hat Single Sign-On container image
+# utilizing specific Keycloak artifacts, stored locally and downloaded in advance
+# See README.adoc and https://docs.cekit.io/en/latest/handbook/overrides.html for details
 artifacts:
       - md5: c6c5690dd226280b612eed960d66a2f9
         path: "jboss-eap-cd.zip"

--- a/overrides/osbs-dev-branch-overrides.yaml
+++ b/overrides/osbs-dev-branch-overrides.yaml
@@ -3,4 +3,4 @@
 osbs:
       repository:
             name: containers/redhat-sso-7
-            branch: jb-sso-cd-dev-rhel-7
+            branch: jb-sso-cd-dev-rhel8

--- a/overrides/osbs-dev-branch-overrides.yaml
+++ b/overrides/osbs-dev-branch-overrides.yaml
@@ -1,0 +1,6 @@
+# CEKit Overrides module to use the -dev branch for the Red Hat Single Sign-On container image in OSBS
+# See README.adoc and https://docs.cekit.io/en/latest/handbook/overrides.html for details
+osbs:
+      repository:
+            name: containers/redhat-sso-7
+            branch: jb-sso-cd-dev-rhel-7


### PR DESCRIPTION
    [KEYCLOAK-10694] Rebase the Red Hat Single Sign-On container image
    on top of the Red Hat Universal Base Image 8 Minimal image.
    Default to OpenJDK JDK 11
    
    Also:
    * Update the CCT module branch to Sprint #35,
    * Update jboss-eap-7-image tag to CD16,
    * **Default to OpenJDK JDK 11**,
    * Introduce 'overrides' subdirectory as a common location to
      keep examples of various CEKit Overrides files. Provide
      example on how to utilize the Overrides file to include JDK 8
      into the image using both CEKit 2.x and CEKit 3.x versions,
    * Introduce 'backward-compatibility' subdirectory as a common
      location to keep various CEKit image descriptor files, that
      need to be archived each time a major, backward-incompatible
      change is introduced to CEKit. Archive image file descriptor,
      used to base the image on RHEL-7, containing 'jboss-os'
      repository definition, and using yum to install the RPM packages.
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
--

    [KEYCLOAK-10124] Define RHEL-8 content set (with RHEL-8 UBI BaseOS
    repo definition) for OSBS builds
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>



Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
