### PR TITLE
[KEYCLOAK-11289] Add 'rhel-8-for-x86_64-appstream-rpms' content set

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -27,6 +27,7 @@ packages:
       content_sets:
             x86_64:
                 - rhel-8-for-x86_64-baseos-rpms
+                - rhel-8-for-x86_64-appstream-rpms
 modules:
       repositories:
           - path: modules


### PR DESCRIPTION
To address build failures like:

`The command '/bin/sh -c microdnf --setopt=tsflags=nodocs install -y java-11-openjdk-devel
&& microdnf clean all && rpm -q java-11-openjdk-devel' returned a non-zero code: 1`

in certain situations

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
