### PR TITLE
[KEYCLOAK-11503] Switch to 'ubi8-minimal:latest'

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,9 +3,7 @@ schema_version: 1
 name: "redhat-sso-cd-tech-preview/sso-cd-rhel8"
 description: "Red Hat Single Sign-On Continuous Delivery container image, based on the Red Hat Universal Base Image 8 Minimal container image"
 version: "7"
-# Strictly stick to 'ubi8-minimal:8.0-131' rather than using 'ubi8-minimal:latest'
-# till RH BZ#1725863 is addressed
-from: "ubi8-minimal:8.0-131"
+from: "ubi8-minimal:latest"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-cd-rhel8-container"


### PR DESCRIPTION
This:
* Is now possible, since RH BZ#1725863 got corrected in the meantime,
* Will allow the RH-SSO CD RHEL-8 container image to pick up latest
  CVE fixes, as needed

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
