### PR TITLE
[KEYCLOAK-11405] Stick the base image down to "ubi8-minimal:8.0-213", IMAGE ID: 8c980b20fbaa

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,13 @@ schema_version: 1
 name: "redhat-sso-cd-tech-preview/sso-cd-rhel8"
 description: "Red Hat Single Sign-On Continuous Delivery container image, based on the Red Hat Universal Base Image 8 Minimal container image"
 version: "7"
-from: "ubi8-minimal:latest"
+# KEYCLOAK-11405 Stick the base image down to "ubi8-minimal:8.0-213" (IMAGE ID == 8c980b20fbaa),
+# so the Red Hat Single Sign-On Continuous Delivery container image contains fixes for both:
+#
+# * The RH BZ#1725863 microdnf bug, and also
+# * The nghttp2 CVE fixes for CVE-2019-9511 and CVE-2019-9513 (RHSA-2019:2692)
+#
+from: "ubi8-minimal:8.0-213"
 labels:
     - name: "com.redhat.component"
       value: "redhat-sso-cd-rhel8-container"


### PR DESCRIPTION
<br/>

**KEYCLOAK-11405:**
<br/>
Stick the base image down to ```ubi8-minimal:8.0-213``` (IMAGE ID: ```8c980b20fbaa```), so
the Red Hat Single Sign-On Continuous Delivery container image contains fixes for both [1]:

- The [RH BZ#1725863 microdnf bug](https://bugzilla.redhat.com/show_bug.cgi?id=1725863), and also
- The nghttp2 CVE fixes for [CVE-2019-9511](https://www.redhat.com/security/data/cve/CVE-2019-9511.html)  and [CVE-2019-9513](https://www.redhat.com/security/data/cve/CVE-2019-9513.html) ([RHSA-2019:2692](https://access.redhat.com/errata/RHSA-2019:2692))

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

<hr/>

[1] Per [c#7 of RH BZ#1725863](https://bugzilla.redhat.com/show_bug.cgi?id=1725863#c7) not every ```ubi8-minimal:latest``` image seem to contain the [RH BZ#1725863](https://bugzilla.redhat.com/show_bug.cgi?id=1725863) change yet.

Thus, it is necessary to choose such an image, simultaneously containing the fix for this bug (so it's possible to install the e.g. ```java-11-openjdk-devel``` and other required RPM packages), and also containing updated ```nghttp2``` RPM package WRT to RHSA-2019:2692.

The ```ubi8-minimal:8.0-213```, chosen above is the _"latest"_ such an image.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
