### PR TITLE
Revert "[KEYCLOAK-12060] Drop the counterpart JDK runtime if primary one is already present"

### DIFF
--- a/modules/sso-rm-openjdk/configure.sh
+++ b/modules/sso-rm-openjdk/configure.sh
@@ -2,34 +2,13 @@
 set -u
 set -e
 
-ARCH=$(uname -i)
-
-# Keep OpenJ9 JDK runtime on s390x arch, and OpenJDK JDK runtime on x86_64 arch
-case "${ARCH}" in
-  x86_64)
-    JDK_VARIANT_TO_KEEP="openjdk"
-    JDK_VARIANT_TO_REMOVE="openj9"
-    ;;
-  s390x)
-    JDK_VARIANT_TO_KEEP="openj9"
-    JDK_VARIANT_TO_REMOVE="openjdk"
-    ;;
-  *)
-    echo "Unsupported architecture: ${ARCH}!"
-    exit 1
-esac
-
-if ! rpm -q java-1.8.0-${JDK_VARIANT_TO_KEEP}-devel; then
+if ! rpm -q java-1.8.0-openj9-devel; then
   exit
 fi
 
-# For the variant of JDK runtime, not applicable to this specific arch
-# remove all of 'java-1.8.0-variant', 'java-1.8.0-variant-devel', and
-# 'java-1.8.0-variant-headless' RPM packages
-
-# NOTE: The enclosing double quote in the list of values specification of the
-# for loop below is intentionally not at the end to perform shell expansion first
-for pkg in "java-1.8.0-${JDK_VARIANT_TO_REMOVE}"{,-devel,-headless}; do
+for pkg in java-1.8.0-openjdk-devel \
+       java-1.8.0-openjdk-headless \
+       java-1.8.0-openjdk; do
     if rpm -q "$pkg"; then
         rpm -e --nodeps "$pkg"
     fi

--- a/modules/sso-rm-openjdk/module.yaml
+++ b/modules/sso-rm-openjdk/module.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 name: sso-rm-openjdk
 version: '1.0'
-description: Remove OpenJDK 1.8 on s390x architecture and OpenJ9 1.8 on x86_64 architecture if on each arch a counterpart JDK is installed
+description: Remove OpenJDK 1.8 if OpenJ9 is present
 
 execute:
 - script: configure.sh


### PR DESCRIPTION
Reverts jboss-container-images/redhat-sso-7-image#102

Per the respective team, the `java-1.8.0-openj9-headless` rpm is pulled in as part of yum transaction & it's expected to be installed.

Thus drop the previous change