### PR TITLE
KEYCLOAK-11941 7.3.6 Rebase RH-SSO z-stream image stream on top of EAP z-stream image

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -9,4 +9,4 @@ compose:
 platforms:
   only:
   - x86_64
-  - s390x
+#  - s390x

--- a/container.yaml
+++ b/container.yaml
@@ -1,5 +1,5 @@
 compose:
-  inherit: true
+  inherit: false
   pulp_repos: true
   packages:
   - java-1.8.0-openj9

--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "redhat-sso-7/sso73"
 description: "Red Hat Single Sign-On 7.3 container image"
-version: "7.3.5.GA"
+version: "7.3.6.GA"
 from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
@@ -10,16 +10,16 @@ labels:
     - name: "org.jboss.product"
       value: "sso"
     - name: "org.jboss.product.version"
-      value: "7.3.5.GA"
+      value: "7.3.6.GA"
     - name: "org.jboss.product.sso.version"
-      value: "7.3.5.GA"
+      value: "7.3.6.GA"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "sso"
     - name: "JBOSS_SSO_VERSION"
-      value: "7.3.5.GA"
+      value: "7.3.6.GA"
     - name: "PRODUCT_VERSION"
-      value: "7.3.5.GA"
+      value: "7.3.6.GA"
 
 modules:
       repositories:
@@ -31,7 +31,7 @@ modules:
           - name: jboss-eap-7-image
             git:
                 url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                ref: EAP_725_CR2_1
+                ref: EAP_726_CR1
       install:
           - name: sso-jdk
             version: '8'


### PR DESCRIPTION
KEYCLOAK-12504 Remove S390 architecture from delivered images
KEYCLOAK-12505 Set inherit to false in container.yaml to mitigate RCM-72893
@pskopek @iankko 