### PR TITLE
KEYCLOAK-12547 7.3.6 OCP build has incorrect EAP version in redhat-ss…

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -44,10 +44,10 @@ modules:
             version: '1.0'
 
 artifacts:
-      - md5: 752aa177b2c18762807dd04f14fad434
-        name: jboss-eap-7.2.5-patch
-        target: jboss-eap-7.2.5-patch.zip
-        url: http://$DOWNLOAD_SERVER/devel/candidates/JBEAP/JBEAP-7.2.5.CP-CR2/jboss-eap-7.2.5.CP-CR2-patch.zip
+      - md5: d407ad9f1e605f2a4cec16ffbea7b3ce
+        name: jboss-eap-7.2.6-patch
+        target: jboss-eap-7.2.6-patch.zip
+        url: http://$DOWNLOAD_SERVER/devel/candidates/JBEAP/JBEAP-7.2.6.CP-CR1/jboss-eap-7.2.6.CP-CR1-patch.zip
 
 # artifacts:
       # Set by the pipeline. Consists of the server overlay zip,


### PR DESCRIPTION
…o-7-image repo

@iankko 
